### PR TITLE
Рефакторинг tagger_node

### DIFF
--- a/config_parser/config_parser.c
+++ b/config_parser/config_parser.c
@@ -1,5 +1,9 @@
 #include "config_parser.h"
+
+#include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
 
 #define FILE_DIR "vlan-tagger.cfg"
 
@@ -427,4 +431,12 @@ char* line_editor(char *string)
     }
 
     return string;
+}
+
+
+void tag_rules_convert_to_host_order(tag_rules_t *rules, const int len) {
+    for (int i = 0; i < len; i++) {
+        rules[i].ip_left.s_addr = ntohl(rules[i].ip_left.s_addr);
+        rules[i].ip_right.s_addr = ntohl(rules[i].ip_right.s_addr);
+    }
 }

--- a/config_parser/config_parser.h
+++ b/config_parser/config_parser.h
@@ -1,13 +1,7 @@
 #ifndef CONFIG_PARSER_H
 #define CONFIG_PARSER_H
 
-#include <arpa/inet.h>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
 typedef struct tag_rules
 {
     struct in_addr ip_left;
@@ -18,6 +12,7 @@ typedef struct tag_rules
 int tag_rules_init(tag_rules_t **, int);
 int tag_rules_clear(tag_rules_t **);
 int tag_rules_check_collisions(const tag_rules_t *, int);
+void tag_rules_convert_to_host_order(tag_rules_t *, int);  // TODO: убрать костыль после рефакторинга правил
 
 int config_file_check(void);
 int config_file_read(tag_rules_t *, int);

--- a/main.c
+++ b/main.c
@@ -15,7 +15,6 @@
 #include "nodes/sniffer_node.h"
 #include "nodes/tagger_node.h"
 #include "nodes/sender_node.h"
-#include "nodes/ip_modifier_node.h"
 #include "nodes/packet_counter_node.h"
 #include "logger/logger.h"
 #include "config_parser/config_parser.h"
@@ -175,6 +174,8 @@ int main(int argc, char *argv[])
         cleanup();
         exit(EXIT_FAILURE);
     }
+
+    tag_rules_convert_to_host_order(global_tag_rules, size);
 
     global_pipeline = pipeline_create();
     if (!global_pipeline)

--- a/nodes/tagger_node.c
+++ b/nodes/tagger_node.c
@@ -1,29 +1,37 @@
 #include "tagger_node.h"
+
+#include <stdio.h>
+
 #include "../logger/logger.h"
 #include "../common.h"
 #include <stdlib.h>
 #include <string.h>
-#include <arpa/inet.h>
+#include <linux/if_ether.h>
 
-Node* tagger_node_create(const char* name, tag_rules_t* tag_rules, int tag_rules_size)
-{
-    if (!name || !tag_rules || tag_rules_size <= 0)
-    {
+#ifndef VLAN_VID_MASK
+#define VLAN_VID_MASK 0x0fff   /* VLAN ID: 12 бит */
+#endif
+
+#ifndef VLAN_HLEN
+#define VLAN_HLEN 4            /* (TPID + TCI) */
+#endif
+#define IP_HEADER_MIN_LEN 20
+
+Node *tagger_node_create(const char *name, tag_rules_t *tag_rules, const int tag_rules_size) {
+    if (!name || !tag_rules || tag_rules_size <= 0) {
         return NULL;
     }
 
-    TaggerContext* ctx = (TaggerContext*)calloc(1, sizeof(TaggerContext));
-    if (!ctx)
-    {
+    TaggerContext *ctx = calloc(1, sizeof(TaggerContext));
+    if (!ctx) {
         return NULL;
     }
 
     ctx->tag_rules = tag_rules;
     ctx->tag_rules_size = tag_rules_size;
 
-    Node* node = node_create(name, NODE_TYPE_TAGGER, tagger_node_process, ctx);
-    if (!node)
-    {
+    Node *node = node_create(name, NODE_TYPE_TAGGER, tagger_node_process, ctx);
+    if (!node) {
         free(ctx);
         return NULL;
     }
@@ -31,136 +39,109 @@ Node* tagger_node_create(const char* name, tag_rules_t* tag_rules, int tag_rules
     return node;
 }
 
-static short tagger_node_define_tag(uint32_t addr, const tag_rules_t* tag_rules_obj, int size)
-{
-    if (tag_rules_obj == NULL)
-    {
-        return -1;
-    }
-
-    if (size == 0)
-    {
-        return -2;
-    }
-
-    for (int i = 0; i < size; ++i)
-    {
-        if (ntohl(tag_rules_obj[i].ip_left.s_addr) <= addr &&
-            ntohl(tag_rules_obj[i].ip_right.s_addr) >= addr)
-        {
-            return (tag_rules_obj)[i].tag;
+static int tagger_node_get_tag(const uint32_t addr, const tag_rules_t *tag_rules_obj, const int num_rules) {
+    for (int i = 0; i < num_rules; ++i) {
+        if (tag_rules_obj[i].ip_left.s_addr <= addr && tag_rules_obj[i].ip_right.s_addr >= addr) {
+            return tag_rules_obj[i].tag;
         }
-    }
-
-    return -3;
-}
-
-static int tagger_node_analyze(unsigned char* buffer)
-{
-    short type_field = 0;
-    type_field = ((0x0000 | (0xff & buffer[12])) << 8) | (0xff & buffer[13]);
-
-    if (type_field <= 1500)
-    {
-        return -1;
-    }
-
-    if (type_field == 0x8100)
-    {
-        return -1;
-    }
-
-    if (type_field != 0x0800)
-    {
-        return -2;
     }
 
     return 0;
 }
 
-static uint32_t tagger_node_get_ip(unsigned char* buffer)
-{
-    uint32_t addr = 0;
+static uint8_t *tagger_node_get_ip_offset(uint8_t *buffer) {
+    constexpr uint16_t offset = ETH_HLEN;
 
-    for (int i = 30; i < 34; i++)
-    {
-        if (i != 33)
-        {
-            addr = (addr | buffer[i]) << 8;
-        }
-        else
-        {
-            addr = (addr | buffer[i]);
-        }
-    }
+    uint16_t ether_type;
+    memcpy(&ether_type, buffer + 12, sizeof(ether_type));
+    ether_type = ntohs(ether_type);
 
-    return addr;
-}
-
-static unsigned short tagger_node_edit_packet(unsigned char* input_buffer, unsigned char* output_buffer, short tag, unsigned short packet_size)
-{
-    for (int i = 0; i < 12; i++)
-    {
-        output_buffer[i] = input_buffer[i];
-    }
-
-    output_buffer[12] = 0x81;
-    output_buffer[13] = 0x00;
-    output_buffer[14] = 0 | 0;
-    output_buffer[14] <<= 1;
-    output_buffer[14] = output_buffer[14] | 0;
-    output_buffer[14] <<= 4;
-    output_buffer[14] = output_buffer[14] | ((0x0f00 & tag) >> 8);
-    output_buffer[15] = 0x00ff & tag;
-
-    for (int i = 12; i < packet_size; i++)
-    {
-        output_buffer[i + 4] = input_buffer[i];
-    }
-
-    packet_size += 4;
-
-    return packet_size;
-}
-
-void* tagger_node_process(void* node_ptr)
-{
-    if (!node_ptr)
-    {
+    if (ether_type <= ETH_DATA_LEN) {
+        // Novell raw IEEE 802.3 non-standard variation frame
         return NULL;
     }
 
-    Node* node = (Node*)node_ptr;
-    TaggerContext* ctx = (TaggerContext*)node->context;
+    switch (ether_type) {
+        case ETH_P_IPV6: // Doesn't support
+        case ETH_P_8021Q: // Doesn't support
+            // offset += 4;
+            return NULL;
+        case ETH_P_IP:
+            return buffer + offset;
+        default:
+            return NULL;
+    }
+}
 
-    if (!ctx || !ctx->tag_rules)
-    {
+static uint32_t tagger_node_get_ip(uint8_t *ip_buffer) {
+    const uint8_t *ip_offset = tagger_node_get_ip_offset(ip_buffer);
+
+    if (!ip_offset) {
+        return 0;
+    }
+
+    const uint8_t *dst_addr = ip_offset + 16;
+    uint32_t addr;
+
+    memcpy(&addr, dst_addr, sizeof(addr));
+
+    return ntohl(addr);
+}
+
+static uint16_t tagger_node_edit_packet(const uint8_t *input_buffer,
+                                        uint8_t *output_buffer,
+                                        const uint16_t vlan_id,
+                                        const uint16_t packet_size)
+{
+    // 1. Copy MACs (6 + 6 = 12)
+    memcpy(output_buffer, input_buffer, 12);
+
+    // 2. TPID = 802.1Q VLAN
+    const uint16_t tpid = htons(ETH_P_8021Q);
+    memcpy(output_buffer + 12, &tpid, sizeof(tpid));
+
+    // 3. TCI: PCP=0, DEI=0, VLAN ID = vlan_id & 0x0FFF
+    const uint16_t tci = htons(vlan_id & VLAN_VID_MASK);
+    memcpy(output_buffer + 14, &tci, sizeof(tci));
+
+    // 4. Other data
+    memcpy(output_buffer + 16, input_buffer + 12, packet_size - 12);
+
+    // 5. Добавили 4 байта VLAN-тега
+    return packet_size + VLAN_HLEN;
+}
+
+void *tagger_node_process(void *node_ptr) {
+    if (!node_ptr) {
+        return NULL;
+    }
+
+    Node *node = node_ptr;
+    TaggerContext *ctx = node->context;
+
+    if (!ctx || !ctx->tag_rules || ctx->tag_rules_size <= 0) {
         printL(ERROR, TAGGER, "%s: Invalid context", node->name);
         return NULL;
     }
 
-    unsigned char buffer[ETHERNET_FRAME_LENGTH] = {0};
-    unsigned char output_buffer[ETHERNET_FRAME_LENGTH] = {0};
-    short tag = 0;
+    uint8_t buffer[ETHERNET_FRAME_LENGTH];
+    uint8_t output_buffer[ETHERNET_FRAME_LENGTH];
     uint32_t addr = 0;
     ssize_t packet_size = 0;
 
     printL(INFO, TAGGER, "Tagger node started: %s", node->name);
 
-    while (!node->should_exit || !*node->should_exit)
-    {
-        if (!node->input_queue)
-        {
+
+    while (!node->should_exit || !*node->should_exit) {
+        if (!node->input_queue) {
             printL(ERROR, TAGGER, "%s: No input queue", node->name);
             break;
         }
 
         packet_size = pop(node->input_queue, buffer);
 
-        if (packet_size < 1)
-        {
-            if (packet_size == 0)
-            {
+        if (packet_size < 1) {
+            if (packet_size == 0) {
                 continue;
             }
 
@@ -168,32 +149,20 @@ void* tagger_node_process(void* node_ptr)
             break;
         }
 
-        if (packet_size < 46)
-        {
-            continue;
-        }
-
-        if (tagger_node_analyze(buffer) != 0)
-        {
-            continue;
+        if (packet_size < ETH_HLEN + IP_HEADER_MIN_LEN) {
+            continue;  // The packet is too short
         }
 
         addr = tagger_node_get_ip(buffer);
 
-        tag = tagger_node_define_tag(addr, (const tag_rules_t*)ctx->tag_rules, ctx->tag_rules_size);
+        if (!addr) {
+            continue;  // Can't get IPv4
+        }
 
-        switch (tag)
-        {
-            case -1:
-            case -2:
-                printL(ERROR, TAGGER, "%s: No tagging rules", node->name);
-                if (node->should_exit)
-                {
-                    *node->should_exit = 1;
-                }
-                return NULL;
-            case -3:
-                continue;
+        const int tag = tagger_node_get_tag(addr, ctx->tag_rules, ctx->tag_rules_size);
+
+        if (tag == 0) {
+            continue;  // No tag
         }
 
         packet_size = tagger_node_edit_packet(buffer, output_buffer, tag, packet_size);


### PR DESCRIPTION
Наводим порядок в существующих узлах нашего конвейера. На очереди tagger.

* пересмотрена работа узла;
* Теперь правила хранятся в прямом порядке байтов. Для этого с помощью костыля перезаписываем все правила единажды. Это необходимо, для удобного сравнения диапазонов адресов внутри tagger'а