### PR TITLE
Config parser refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ sudo ./netns_blackhole.sh up
 
 ```bash
 cd build
-sudo ./vlan_tagger veth0
+sudo ./vlan_tagger veth0 veth1
 ```
+
+Аргументы:
+- `veth0` (первый) - source interface для Sniffer
+- `veth1` (второй) - destination interface для Sender
 
 ## Ручное тестирование
 

--- a/config_parser/config_parser.c
+++ b/config_parser/config_parser.c
@@ -1,259 +1,29 @@
+#define _GNU_SOURCE
+
 #include "config_parser.h"
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#include <errno.h>
+#include <limits.h>
 
 #define FILE_DIR "vlan-tagger.cfg"
+#define MAX_LINE_LENGTH 100
+#define MAX_RULE_CONTENT_LENGTH 37
+#define MIN_VLAN_ID 0
+#define MAX_VLAN_ID 4096
+#define DEFAULT_INITIAL_CAPACITY 16
+#define CAPACITY_GROWTH_FACTOR 2
+
+static int tag_rules_ensure_capacity(tag_rules_t *tag_rules, int required_size);
 
 int ip_converting(struct in_addr *, const char *);
 char* line_editor(char *);
 int tag_converting(int *, const char *);
 int ip_comparison(const struct in_addr, const struct in_addr);
-int ip_str_to_int(char *, int *);
 int char_count(const char *, char);
-
-int tag_rules_init(tag_rule_t **tag_rules_obj, int size)
-{
-    if (*tag_rules_obj != NULL || size <= 0)
-    {
-        return -1;
-    }
-
-    *tag_rules_obj = (tag_rule_t*) calloc(size, sizeof(tag_rule_t));
-
-    if (tag_rules_obj == NULL)
-    {
-        return -2;
-    }
-
-    return 0;
-}
-
-int tag_rules_clear(tag_rule_t **tag_rules_obj)
-{
-    if (*tag_rules_obj == NULL)
-    {
-        return -1;
-    }
-
-    free(*tag_rules_obj);
-
-    return 0;
-}
-
-int tag_rules_check_collisions(const tag_rule_t *tag_rules_obj, int size)
-{
-    if (tag_rules_obj == NULL || size <= 0)
-    {
-        return -1;
-    }
-
-    int err_count = 0;
-    for (int i = 0; i < size; i++)
-    {
-        int res = ip_comparison(tag_rules_obj[i].ip_left, tag_rules_obj[i].ip_right);
-        if (res < 0)
-        {
-            return -2;
-        }
-        else if (res > 1)
-        {
-            err_count++;
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    err_count = 0;
-    for (int i = 0; i < size; i++)
-    {
-        for (int j = i + 1; j < size; j++)
-        {
-            int res_iright_jleft = ip_comparison(tag_rules_obj[i].ip_right, tag_rules_obj[j].ip_left);
-            if (res_iright_jleft < 0)
-            {
-                return -2;
-            }
-            else if (res_iright_jleft == 0)
-            {
-                continue;
-            }
-            else
-            {
-                int res_jright_ileft = ip_comparison(tag_rules_obj[j].ip_right, tag_rules_obj[i].ip_left);
-                if (res_jright_ileft < 0)
-                {
-                    return -2;
-                }
-                else if (res_jright_ileft == 0)
-                {
-                    continue;
-                }
-                else
-                {
-                    err_count++;
-                }
-            }
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    err_count = 0;
-    for (int i = 0; i < size; i++)
-    {
-        if (tag_rules_obj[i].tag < 0 || tag_rules_obj[i].tag > 4096)
-        {
-            err_count++;
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    return 0;
-}
-
-int config_file_check(void)
-{
-    FILE *pFile;
-    if ((pFile = fopen(FILE_DIR, "r")) == NULL)
-    {
-        return -1;
-    }
-
-    if (fclose(pFile) > 0)
-    {
-        return -2;
-    }
-
-    return 0;
-}
-
-int config_file_read(tag_rule_t *tag_rules_obj, int size)
-{
-    if (tag_rules_obj == NULL)
-    {
-        return -1;
-    }
-
-	int i;
-    FILE* pfile;
-    if ((pfile = fopen(FILE_DIR, "r")) == NULL)
-    {
-        return -2;
-    }
-
-    for (i = 0;; i++)
-    {
-		char rule[100] = { 0 };
-        char *prule;
-        char *rule_part;
-        int full_stop_count;
-		
-        if (i == size)
-        {
-            break;
-        }
-
-        prule = fgets(rule, sizeof(rule), pfile);
-        if (prule == NULL)
-        {
-            if (feof(pfile) != 0)
-            {
-                break;
-            }
-            else
-            {
-                fclose(pfile);
-                return -4;
-            }
-        }
-
-        char* real_start;
-        if ((real_start = line_editor(rule)) == NULL)
-        {
-            fclose(pfile);
-            return -10;
-        }
-
-        if (*real_start == '\0' || *real_start == '#' || *real_start == '\n')
-        {
-            --i;
-            continue;
-        }
-
-        full_stop_count = char_count(real_start, '-');
-        if (full_stop_count < 1 || full_stop_count > 2)
-        {
-            fclose(pfile);
-            return -5;
-        }
-
-        rule_part = strtok(real_start, "-");
-        if (rule_part == NULL)
-        {
-            fclose(pfile);
-            return -6;
-        }
-
-        if (ip_converting(&tag_rules_obj[i].ip_left, rule_part) != 0)
-        {
-            fclose(pfile);
-            return -7;
-        }
-
-        if (full_stop_count == 1)
-        {
-            tag_rules_obj[i].ip_right = tag_rules_obj[i].ip_left;
-        }
-        else
-        {
-            rule_part = strtok(NULL, "-");
-            if (rule_part == NULL)
-            {
-                fclose(pfile);
-                return -6;
-            }
-
-            if (ip_converting(&tag_rules_obj[i].ip_right, rule_part) != 0)
-            {
-                fclose(pfile);
-                return -7;
-            }
-        }
-
-        rule_part = strtok(NULL, "-");
-        if (rule_part == NULL)
-        {
-            fclose(pfile);
-            return -6;
-        }
-
-        if (tag_converting(&tag_rules_obj[i].tag, rule_part) != 0)
-        {
-            fclose(pfile);
-            return -8;
-        }
-    }
-
-    if (fclose(pfile) == EOF)
-    {
-        return -9;
-    }
-
-    return i;
-}
 
 int ip_converting(struct in_addr *in_addr_obj, const char *ip_str)
 {
@@ -277,100 +47,42 @@ int tag_converting(int *tag_int, const char *tag_str)
         return -1;
     }
 
-	int tag_int_tmp;
-    tag_int_tmp = atoi(tag_str);
-    if (tag_int_tmp == 0 && tag_str[0] != '0')
+    char *endptr;
+    errno = 0;
+    long tag_long = strtol(tag_str, &endptr, 10);
+
+    if (errno == ERANGE || tag_long < INT_MIN || tag_long > INT_MAX)
     {
         return -2;
     }
 
-    *tag_int = tag_int_tmp;
+    if (endptr == tag_str || *endptr != '\0')
+    {
+        return -3;
+    }
+
+    *tag_int = (int)tag_long;
 
     return 0;
 }
 
 int ip_comparison(const struct in_addr ip_1, const struct in_addr ip_2)
 {
-    char ip_1_str[16] = { 0 };
-    char ip_2_str[16] = { 0 };
-    char *pip_1_str = ip_1_str;
-    char *pip_2_str = ip_2_str;
-    char *ip_1_str_tmp;
-    char *ip_2_str_tmp;
-	int ip_1_int[4] = { 0 };
-    int ip_2_int[4] = { 0 };
+    uint32_t addr1_host = ntohl(ip_1.s_addr);
+    uint32_t addr2_host = ntohl(ip_2.s_addr);
 
-    ip_1_str_tmp = inet_ntoa(ip_1);
-    if (ip_1_str_tmp == NULL)
+    if (addr1_host < addr2_host)
     {
-        return -1;
+        return 0;
     }
-
-    memcpy(pip_1_str, ip_1_str_tmp, strlen(ip_1_str_tmp) + 1);
-
-    ip_2_str_tmp = inet_ntoa(ip_2);
-    if (pip_2_str == NULL)
+    else if (addr1_host == addr2_host)
     {
-        return -1;
+        return 1;
     }
-
-    memcpy(pip_2_str, ip_2_str_tmp, strlen(ip_2_str_tmp) + 1);
-
-    if (ip_str_to_int(pip_1_str, ip_1_int) != 0)
+    else
     {
-        return -2;
+        return 2;
     }
-    if (ip_str_to_int(pip_2_str, ip_2_int) != 0)
-    {
-        return -2;
-    }
-
-    for (int i = 0; i < 4; i++)
-    {
-        if (ip_1_int[i] < ip_2_int[i])
-        {
-            return 0;
-        }
-        else if (ip_1_int[i] == ip_2_int[i])
-        {
-            if (i == 3)
-            {
-                return 1;
-            }
-            else
-            {
-                continue;
-            }
-        }
-        else if (ip_1_int[i] > ip_2_int[i])
-        {
-            return 2;
-        }
-    }
-}
-
-int ip_str_to_int(char *ip_str, int *ip_int)
-{
-    if (ip_str == NULL || ip_int == NULL)
-    {
-        return -1;
-    }
-
-    int i = 0;
-    char *ip_str_part = strtok(ip_str, ".");
-    while (ip_str_part != NULL)
-    {
-        ip_int[i] = atoi(ip_str_part);
-        if (ip_int[i] == 0 && ip_str_part[0] != '0')
-        {
-            return -2;
-        }
-
-        i++;
-        ip_str_part = strtok(NULL, ".");
-    }
-
-    return 0;
 }
 
 int char_count(const char *str, char symbol)
@@ -417,13 +129,9 @@ char* line_editor(char *string)
     }
 
     //Поиск пробелов или табуляций до комментариев
-    for (char j = 0; j < 37; j++)
+    for (char j = 0; j < MAX_RULE_CONTENT_LENGTH; j++)
     {
-        if (string[j] == '\n')
-        {
-            continue;
-        }
-        if (string[j] == ' ' || string[j] == '\t' || string[j] == '#')
+        if (string[j] == ' ' || string[j] == '\t' || string[j] == '#' || string[j] == '\n')
         {
             string[j] = '\0';
             break;
@@ -433,10 +141,322 @@ char* line_editor(char *string)
     return string;
 }
 
-
-void tag_rules_convert_to_host_order(tag_rule_t *rules, const int len) {
-    for (int i = 0; i < len; i++) {
-        rules[i].ip_left.s_addr = ntohl(rules[i].ip_left.s_addr);
-        rules[i].ip_right.s_addr = ntohl(rules[i].ip_right.s_addr);
+int tag_rules_init(tag_rules_t *tag_rules, int initial_capacity)
+{
+    if (tag_rules == NULL)
+    {
+        return -1;
     }
+
+    if (tag_rules->rules != NULL)
+    {
+        return -1;
+    }
+
+    if (initial_capacity <= 0)
+    {
+        initial_capacity = DEFAULT_INITIAL_CAPACITY;
+    }
+
+    tag_rules->rules = (tag_rule_t*)calloc(initial_capacity, sizeof(tag_rule_t));
+    if (tag_rules->rules == NULL)
+    {
+        return -2;
+    }
+
+    tag_rules->size = 0;
+    tag_rules->capacity = initial_capacity;
+
+    return 0;
+}
+
+void tag_rules_destroy(tag_rules_t *tag_rules)
+{
+    if (tag_rules == NULL)
+    {
+        return;
+    }
+
+    if (tag_rules->rules != NULL)
+    {
+        free(tag_rules->rules);
+        tag_rules->rules = NULL;
+    }
+
+    tag_rules->size = 0;
+    tag_rules->capacity = 0;
+}
+
+const tag_rule_t* tag_rules_get_array(const tag_rules_t *tag_rules)
+{
+    if (tag_rules == NULL)
+    {
+        return NULL;
+    }
+
+    return tag_rules->rules;
+}
+
+int tag_rules_get_size(const tag_rules_t *tag_rules)
+{
+    if (tag_rules == NULL)
+    {
+        return -1;
+    }
+
+    return tag_rules->size;
+}
+
+static int tag_rules_ensure_capacity(tag_rules_t *tag_rules, int required_size)
+{
+    if (tag_rules == NULL || tag_rules->rules == NULL)
+    {
+        return -1;
+    }
+
+    if (required_size <= tag_rules->capacity)
+    {
+        return 0;
+    }
+
+    int new_capacity = tag_rules->capacity;
+    while (new_capacity < required_size)
+    {
+        new_capacity *= CAPACITY_GROWTH_FACTOR;
+    }
+
+    tag_rule_t *new_rules = (tag_rule_t*)realloc(tag_rules->rules,
+                                                   new_capacity * sizeof(tag_rule_t));
+    if (new_rules == NULL)
+    {
+        return -2;
+    }
+
+    memset(new_rules + tag_rules->capacity, 0,
+           (new_capacity - tag_rules->capacity) * sizeof(tag_rule_t));
+
+    tag_rules->rules = new_rules;
+    tag_rules->capacity = new_capacity;
+
+    return 0;
+}
+
+int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
+{
+    if (tag_rules == NULL || config_path == NULL)
+    {
+        return -1;
+    }
+
+    if (tag_rules->rules == NULL)
+    {
+        return -2;
+    }
+
+    FILE *pfile = fopen(config_path, "r");
+    if (pfile == NULL)
+    {
+        return -3;
+    }
+
+    int loaded_count = 0;
+
+    for (;;)
+    {
+        char rule[MAX_LINE_LENGTH] = { 0 };
+        char *prule;
+        char *rule_part;
+        char *saveptr;
+        int dash_count;
+
+        prule = fgets(rule, sizeof(rule), pfile);
+        if (prule == NULL)
+        {
+            if (feof(pfile) != 0)
+            {
+                break;
+            }
+            else
+            {
+                fclose(pfile);
+                return -4;
+            }
+        }
+
+        char* real_start = line_editor(rule);
+        if (real_start == NULL)
+        {
+            fclose(pfile);
+            return -10;
+        }
+
+        if (*real_start == '\0' || *real_start == '#' || *real_start == '\n')
+        {
+            continue;
+        }
+
+        dash_count = char_count(real_start, '-');
+        if (dash_count < 1 || dash_count > 2)
+        {
+            fclose(pfile);
+            return -5;
+        }
+
+        if (tag_rules_ensure_capacity(tag_rules, loaded_count + 1) != 0)
+        {
+            fclose(pfile);
+            return -11;
+        }
+
+        rule_part = strtok_r(real_start, "-", &saveptr);
+        if (rule_part == NULL)
+        {
+            fclose(pfile);
+            return -6;
+        }
+
+        if (ip_converting(&tag_rules->rules[loaded_count].ip_left, rule_part) != 0)
+        {
+            fclose(pfile);
+            return -7;
+        }
+
+        if (dash_count == 1)
+        {
+            tag_rules->rules[loaded_count].ip_right = tag_rules->rules[loaded_count].ip_left;
+        }
+        else
+        {
+            rule_part = strtok_r(NULL, "-", &saveptr);
+            if (rule_part == NULL)
+            {
+                fclose(pfile);
+                return -6;
+            }
+
+            if (ip_converting(&tag_rules->rules[loaded_count].ip_right, rule_part) != 0)
+            {
+                fclose(pfile);
+                return -7;
+            }
+        }
+
+        rule_part = strtok_r(NULL, "-", &saveptr);
+        if (rule_part == NULL)
+        {
+            fclose(pfile);
+            return -6;
+        }
+
+        if (tag_converting(&tag_rules->rules[loaded_count].tag, rule_part) != 0)
+        {
+            fclose(pfile);
+            return -8;
+        }
+
+        loaded_count++;
+    }
+
+    if (fclose(pfile) == EOF)
+    {
+        return -9;
+    }
+
+    tag_rules->size = loaded_count;
+
+    return loaded_count;
+}
+
+int tag_rules_validate(const tag_rules_t *tag_rules)
+{
+    if (tag_rules == NULL || tag_rules->rules == NULL)
+    {
+        return -1;
+    }
+
+    if (tag_rules->size <= 0)
+    {
+        return -1;
+    }
+
+    int err_count = 0;
+
+    // Проверка 1: ip_left <= ip_right в каждом правиле
+    for (int i = 0; i < tag_rules->size; i++)
+    {
+        int res = ip_comparison(tag_rules->rules[i].ip_left,
+                                tag_rules->rules[i].ip_right);
+        if (res < 0)
+        {
+            return -2;
+        }
+        else if (res > 1)
+        {
+            err_count++;
+        }
+    }
+
+    if (err_count > 0)
+    {
+        return err_count;
+    }
+
+    // Проверка 2: коллизии диапазонов
+    err_count = 0;
+    for (int i = 0; i < tag_rules->size; i++)
+    {
+        for (int j = i + 1; j < tag_rules->size; j++)
+        {
+            int res_iright_jleft = ip_comparison(tag_rules->rules[i].ip_right,
+                                                  tag_rules->rules[j].ip_left);
+            if (res_iright_jleft < 0)
+            {
+                return -2;
+            }
+            else if (res_iright_jleft == 0)
+            {
+                continue;
+            }
+            else
+            {
+                int res_jright_ileft = ip_comparison(tag_rules->rules[j].ip_right,
+                                                      tag_rules->rules[i].ip_left);
+                if (res_jright_ileft < 0)
+                {
+                    return -2;
+                }
+                else if (res_jright_ileft == 0)
+                {
+                    continue;
+                }
+                else
+                {
+                    err_count++;
+                }
+            }
+        }
+    }
+
+    if (err_count > 0)
+    {
+        return err_count;
+    }
+
+    // Проверка 3: валидность VLAN ID
+    err_count = 0;
+    for (int i = 0; i < tag_rules->size; i++)
+    {
+        if (tag_rules->rules[i].tag < MIN_VLAN_ID ||
+            tag_rules->rules[i].tag > MAX_VLAN_ID)
+        {
+            err_count++;
+        }
+    }
+
+    if (err_count > 0)
+    {
+        return err_count;
+    }
+
+    return 0;
 }

--- a/config_parser/config_parser.c
+++ b/config_parser/config_parser.c
@@ -9,23 +9,12 @@
 #include <errno.h>
 #include <limits.h>
 
-#define FILE_DIR "vlan-tagger.cfg"
 #define MAX_LINE_LENGTH 100
 #define MAX_RULE_CONTENT_LENGTH 37
 #define MIN_VLAN_ID 0
-#define MAX_VLAN_ID 4096
-#define DEFAULT_INITIAL_CAPACITY 16
-#define CAPACITY_GROWTH_FACTOR 2
+#define MAX_VLAN_ID 4095
 
-static int tag_rules_ensure_capacity(tag_rules_t *tag_rules, int required_size);
-
-int ip_converting(struct in_addr *, const char *);
-char* line_editor(char *);
-int tag_converting(int *, const char *);
-int ip_comparison(const struct in_addr, const struct in_addr);
-int char_count(const char *, char);
-
-int ip_converting(struct in_addr *in_addr_obj, const char *ip_str)
+static int ip_converting(struct in_addr *in_addr_obj, const char *ip_str)
 {
     if (in_addr_obj == NULL || ip_str == NULL)
     {
@@ -34,13 +23,13 @@ int ip_converting(struct in_addr *in_addr_obj, const char *ip_str)
 
     if (inet_aton(ip_str, in_addr_obj) == 0)
     {
-        return -2;
+        return -1;
     }
 
     return 0;
 }
 
-int tag_converting(int *tag_int, const char *tag_str)
+static int tag_converting(int *tag_int, const char *tag_str)
 {
     if (tag_int == NULL || tag_str == NULL)
     {
@@ -53,12 +42,12 @@ int tag_converting(int *tag_int, const char *tag_str)
 
     if (errno == ERANGE || tag_long < INT_MIN || tag_long > INT_MAX)
     {
-        return -2;
+        return -1;
     }
 
     if (endptr == tag_str || *endptr != '\0')
     {
-        return -3;
+        return -1;
     }
 
     *tag_int = (int)tag_long;
@@ -66,26 +55,7 @@ int tag_converting(int *tag_int, const char *tag_str)
     return 0;
 }
 
-int ip_comparison(const struct in_addr ip_1, const struct in_addr ip_2)
-{
-    uint32_t addr1_host = ntohl(ip_1.s_addr);
-    uint32_t addr2_host = ntohl(ip_2.s_addr);
-
-    if (addr1_host < addr2_host)
-    {
-        return 0;
-    }
-    else if (addr1_host == addr2_host)
-    {
-        return 1;
-    }
-    else
-    {
-        return 2;
-    }
-}
-
-int char_count(const char *str, char symbol)
+static int char_count(const char *str, char symbol)
 {
     if (str == NULL)
     {
@@ -93,7 +63,7 @@ int char_count(const char *str, char symbol)
     }
 
     int count = 0;
-    for (int i = 0; i < strlen(str); i++)
+    for (size_t i = 0; i < strlen(str); i++)
     {
         if (str[i] == symbol)
         {
@@ -104,16 +74,15 @@ int char_count(const char *str, char symbol)
     return count;
 }
 
-char* line_editor(char *string)
+static char* line_editor(char *string)
 {
     if (!string)
     {
         return NULL;
     }
 
-    //Поиск начала строки
-    unsigned long i;
-    for (i = 0; i < strlen(string); ++i)
+    // Поиск начала строки (пропуск пробелов и табов)
+    for (size_t i = 0; i < strlen(string); ++i)
     {
         if (string[i] != ' ' && string[i] != '\t')
         {
@@ -122,14 +91,14 @@ char* line_editor(char *string)
         }
     }
 
-    // Ситуация, когда вся строка - комментарий
+    // Строка-комментарий
     if (*string == '#')
     {
         return string;
     }
 
-    //Поиск пробелов или табуляций до комментариев
-    for (char j = 0; j < MAX_RULE_CONTENT_LENGTH; j++)
+    // Обрезаем строку на первом пробеле/табе/комментарии
+    for (int j = 0; j < MAX_RULE_CONTENT_LENGTH; j++)
     {
         if (string[j] == ' ' || string[j] == '\t' || string[j] == '#' || string[j] == '\n')
         {
@@ -141,123 +110,67 @@ char* line_editor(char *string)
     return string;
 }
 
-int tag_rules_init(tag_rules_t *tag_rules, int initial_capacity)
+static int validate_rules(const tag_rules_t *tag_rules)
 {
-    if (tag_rules == NULL)
+    // Проверка 1: ip_left <= ip_right в каждом правиле
+    for (int i = 0; i < tag_rules->size; i++)
     {
-        return -1;
+        uint32_t left = ntohl(tag_rules->rules[i].ip_left.s_addr);
+        uint32_t right = ntohl(tag_rules->rules[i].ip_right.s_addr);
+
+        if (left > right)
+        {
+            return -11;
+        }
     }
 
-    if (tag_rules->rules != NULL)
+    // Проверка 2: коллизии диапазонов
+    for (int i = 0; i < tag_rules->size; i++)
     {
-        return -1;
+        uint32_t i_left = ntohl(tag_rules->rules[i].ip_left.s_addr);
+        uint32_t i_right = ntohl(tag_rules->rules[i].ip_right.s_addr);
+
+        for (int j = i + 1; j < tag_rules->size; j++)
+        {
+            uint32_t j_left = ntohl(tag_rules->rules[j].ip_left.s_addr);
+            uint32_t j_right = ntohl(tag_rules->rules[j].ip_right.s_addr);
+
+            // Проверка пересечения: !(i_right < j_left || j_right < i_left)
+            if (!(i_right < j_left || j_right < i_left))
+            {
+                return -12;
+            }
+        }
     }
 
-    if (initial_capacity <= 0)
+    // Проверка 3: валидность VLAN ID
+    for (int i = 0; i < tag_rules->size; i++)
     {
-        initial_capacity = DEFAULT_INITIAL_CAPACITY;
+        if (tag_rules->rules[i].tag < MIN_VLAN_ID ||
+            tag_rules->rules[i].tag > MAX_VLAN_ID)
+        {
+            return -13;
+        }
     }
-
-    tag_rules->rules = (tag_rule_t*)calloc(initial_capacity, sizeof(tag_rule_t));
-    if (tag_rules->rules == NULL)
-    {
-        return -2;
-    }
-
-    tag_rules->size = 0;
-    tag_rules->capacity = initial_capacity;
 
     return 0;
 }
 
-void tag_rules_destroy(tag_rules_t *tag_rules)
-{
-    if (tag_rules == NULL)
-    {
-        return;
-    }
-
-    if (tag_rules->rules != NULL)
-    {
-        free(tag_rules->rules);
-        tag_rules->rules = NULL;
-    }
-
-    tag_rules->size = 0;
-    tag_rules->capacity = 0;
-}
-
-const tag_rule_t* tag_rules_get_array(const tag_rules_t *tag_rules)
-{
-    if (tag_rules == NULL)
-    {
-        return NULL;
-    }
-
-    return tag_rules->rules;
-}
-
-int tag_rules_get_size(const tag_rules_t *tag_rules)
-{
-    if (tag_rules == NULL)
-    {
-        return -1;
-    }
-
-    return tag_rules->size;
-}
-
-static int tag_rules_ensure_capacity(tag_rules_t *tag_rules, int required_size)
-{
-    if (tag_rules == NULL || tag_rules->rules == NULL)
-    {
-        return -1;
-    }
-
-    if (required_size <= tag_rules->capacity)
-    {
-        return 0;
-    }
-
-    int new_capacity = tag_rules->capacity;
-    while (new_capacity < required_size)
-    {
-        new_capacity *= CAPACITY_GROWTH_FACTOR;
-    }
-
-    tag_rule_t *new_rules = (tag_rule_t*)realloc(tag_rules->rules,
-                                                   new_capacity * sizeof(tag_rule_t));
-    if (new_rules == NULL)
-    {
-        return -2;
-    }
-
-    memset(new_rules + tag_rules->capacity, 0,
-           (new_capacity - tag_rules->capacity) * sizeof(tag_rule_t));
-
-    tag_rules->rules = new_rules;
-    tag_rules->capacity = new_capacity;
-
-    return 0;
-}
-
-int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
+int tag_rules_load(tag_rules_t *tag_rules, const char *config_path)
 {
     if (tag_rules == NULL || config_path == NULL)
     {
         return -1;
     }
 
-    if (tag_rules->rules == NULL)
+    FILE *pfile = fopen(config_path, "r");
+    if (pfile == NULL)
     {
         return -2;
     }
 
-    FILE *pfile = fopen(config_path, "r");
-    if (pfile == NULL)
-    {
-        return -3;
-    }
+    // Обнуляем структуру перед загрузкой
+    memset(tag_rules, 0, sizeof(tag_rules_t));
 
     int loaded_count = 0;
 
@@ -279,7 +192,7 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
             else
             {
                 fclose(pfile);
-                return -4;
+                return -3;
             }
         }
 
@@ -287,7 +200,7 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
         if (real_start == NULL)
         {
             fclose(pfile);
-            return -10;
+            return -4;
         }
 
         if (*real_start == '\0' || *real_start == '#' || *real_start == '\n')
@@ -302,23 +215,23 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
             return -5;
         }
 
-        if (tag_rules_ensure_capacity(tag_rules, loaded_count + 1) != 0)
+        if (loaded_count >= MAX_RULES)
         {
             fclose(pfile);
-            return -11;
+            return -6;
         }
 
         rule_part = strtok_r(real_start, "-", &saveptr);
         if (rule_part == NULL)
         {
             fclose(pfile);
-            return -6;
+            return -7;
         }
 
         if (ip_converting(&tag_rules->rules[loaded_count].ip_left, rule_part) != 0)
         {
             fclose(pfile);
-            return -7;
+            return -8;
         }
 
         if (dash_count == 1)
@@ -331,13 +244,13 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
             if (rule_part == NULL)
             {
                 fclose(pfile);
-                return -6;
+                return -7;
             }
 
             if (ip_converting(&tag_rules->rules[loaded_count].ip_right, rule_part) != 0)
             {
                 fclose(pfile);
-                return -7;
+                return -8;
             }
         }
 
@@ -345,13 +258,13 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
         if (rule_part == NULL)
         {
             fclose(pfile);
-            return -6;
+            return -7;
         }
 
         if (tag_converting(&tag_rules->rules[loaded_count].tag, rule_part) != 0)
         {
             fclose(pfile);
-            return -8;
+            return -9;
         }
 
         loaded_count++;
@@ -359,104 +272,20 @@ int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path)
 
     if (fclose(pfile) == EOF)
     {
-        return -9;
+        return -10;
     }
 
     tag_rules->size = loaded_count;
 
+    // Валидация загруженных правил
+    if (loaded_count > 0)
+    {
+        int validation_result = validate_rules(tag_rules);
+        if (validation_result != 0)
+        {
+            return validation_result;
+        }
+    }
+
     return loaded_count;
-}
-
-int tag_rules_validate(const tag_rules_t *tag_rules)
-{
-    if (tag_rules == NULL || tag_rules->rules == NULL)
-    {
-        return -1;
-    }
-
-    if (tag_rules->size <= 0)
-    {
-        return -1;
-    }
-
-    int err_count = 0;
-
-    // Проверка 1: ip_left <= ip_right в каждом правиле
-    for (int i = 0; i < tag_rules->size; i++)
-    {
-        int res = ip_comparison(tag_rules->rules[i].ip_left,
-                                tag_rules->rules[i].ip_right);
-        if (res < 0)
-        {
-            return -2;
-        }
-        else if (res > 1)
-        {
-            err_count++;
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    // Проверка 2: коллизии диапазонов
-    err_count = 0;
-    for (int i = 0; i < tag_rules->size; i++)
-    {
-        for (int j = i + 1; j < tag_rules->size; j++)
-        {
-            int res_iright_jleft = ip_comparison(tag_rules->rules[i].ip_right,
-                                                  tag_rules->rules[j].ip_left);
-            if (res_iright_jleft < 0)
-            {
-                return -2;
-            }
-            else if (res_iright_jleft == 0)
-            {
-                continue;
-            }
-            else
-            {
-                int res_jright_ileft = ip_comparison(tag_rules->rules[j].ip_right,
-                                                      tag_rules->rules[i].ip_left);
-                if (res_jright_ileft < 0)
-                {
-                    return -2;
-                }
-                else if (res_jright_ileft == 0)
-                {
-                    continue;
-                }
-                else
-                {
-                    err_count++;
-                }
-            }
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    // Проверка 3: валидность VLAN ID
-    err_count = 0;
-    for (int i = 0; i < tag_rules->size; i++)
-    {
-        if (tag_rules->rules[i].tag < MIN_VLAN_ID ||
-            tag_rules->rules[i].tag > MAX_VLAN_ID)
-        {
-            err_count++;
-        }
-    }
-
-    if (err_count > 0)
-    {
-        return err_count;
-    }
-
-    return 0;
 }

--- a/config_parser/config_parser.h
+++ b/config_parser/config_parser.h
@@ -2,6 +2,7 @@
 #define CONFIG_PARSER_H
 
 #include <netinet/in.h>
+
 typedef struct tag_rules
 {
     struct in_addr ip_left;
@@ -12,14 +13,14 @@ typedef struct tag_rules
 typedef struct {
     tag_rule_t* rules;
     int size;
-} tag_rules_t; // TODO: нужно пересмотреть проект и переписать раздельное использование массива правил и размера на единую структуру
+    int capacity;
+} tag_rules_t;
 
-int tag_rules_init(tag_rule_t **, int);
-int tag_rules_clear(tag_rule_t **);
-int tag_rules_check_collisions(const tag_rule_t *, int);
-void tag_rules_convert_to_host_order(tag_rule_t *, int);  // TODO: убрать костыль после рефакторинга правил
-
-int config_file_check(void);
-int config_file_read(tag_rule_t *, int);
+int tag_rules_init(tag_rules_t *tag_rules, int initial_capacity);
+void tag_rules_destroy(tag_rules_t *tag_rules);
+int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path);
+int tag_rules_validate(const tag_rules_t *tag_rules);
+const tag_rule_t* tag_rules_get_array(const tag_rules_t *tag_rules);
+int tag_rules_get_size(const tag_rules_t *tag_rules);
 
 #endif

--- a/config_parser/config_parser.h
+++ b/config_parser/config_parser.h
@@ -3,24 +3,41 @@
 
 #include <netinet/in.h>
 
-typedef struct tag_rules
-{
+#define MAX_RULES 128
+
+typedef struct {
     struct in_addr ip_left;
     struct in_addr ip_right;
     int tag;
 } tag_rule_t;
 
 typedef struct {
-    tag_rule_t* rules;
+    tag_rule_t rules[MAX_RULES];
     int size;
-    int capacity;
 } tag_rules_t;
 
-int tag_rules_init(tag_rules_t *tag_rules, int initial_capacity);
-void tag_rules_destroy(tag_rules_t *tag_rules);
-int tag_rules_load_from_file(tag_rules_t *tag_rules, const char *config_path);
-int tag_rules_validate(const tag_rules_t *tag_rules);
-const tag_rule_t* tag_rules_get_array(const tag_rules_t *tag_rules);
-int tag_rules_get_size(const tag_rules_t *tag_rules);
+/**
+ * Загружает и валидирует правила тегирования из файла.
+ *
+ * @param tag_rules указатель на структуру для записи правил
+ * @param config_path путь к конфигурационному файлу
+ * @return количество загруженных правил (>= 0) или код ошибки (< 0)
+ *
+ * Коды ошибок:
+ *  -1: невалидные аргументы
+ *  -2: не удалось открыть файл
+ *  -3: ошибка чтения файла
+ *  -4: ошибка парсинга строки
+ *  -5: неверный формат правила (количество дефисов)
+ *  -6: превышен лимит правил (MAX_RULES)
+ *  -7: ошибка парсинга токена
+ *  -8: невалидный IP адрес
+ *  -9: невалидный VLAN ID
+ * -10: ошибка закрытия файла
+ * -11: ip_left > ip_right в правиле
+ * -12: пересечение диапазонов IP
+ * -13: VLAN ID вне диапазона 0-4095
+ */
+int tag_rules_load(tag_rules_t *tag_rules, const char *config_path);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -30,44 +30,44 @@ static void cleanup(void)
 {
     pipeline_destroy(&global_pipeline);
 
-    if (global_tag_rules.rules)
-    {
-        tag_rules_clear(&global_tag_rules.rules);
-        printL(INFO, INITIATOR, "Tag rules cleared.");
-    }
+    tag_rules_destroy(&global_tag_rules);
+    printL(INFO, INITIATOR, "Tag rules destroyed.");
 
     stop_log();
 }
 
-static int fill_tag_rules(tag_rules_t *tag_rules_ptr) {
-    if (config_file_check() != 0)
+static int fill_tag_rules(tag_rules_t *tag_rules_ptr, const char *config_path) {
+    // Инициализация
+    if (tag_rules_init(tag_rules_ptr, 0) != 0)
     {
-        printL(ERROR, PARSER, "Error opening/closing config file!");
+        printL(ERROR, PARSER, "Error initializing tag rules structure!");
         return 1;
     }
 
-    if (tag_rules_init(&tag_rules_ptr->rules, 64) != 0)
+    // Загрузка
+    const int loaded_count = tag_rules_load_from_file(tag_rules_ptr, config_path);
+    if (loaded_count < 0)
     {
-        printL(ERROR, PARSER, "Error allocating memory for tag rules!");
+        printL(ERROR, PARSER, "Error loading config file (code: %d)!", loaded_count);
+        tag_rules_destroy(tag_rules_ptr);
         return 1;
     }
 
-    const int size = config_file_read(tag_rules_ptr->rules, 64);
-    if (size < 0)
+    if (loaded_count == 0)
     {
-        printL(ERROR, PARSER, "Error reading config file!");
+        printL(WARNING, PARSER, "No rules loaded from config file!");
+    }
+
+    // Валидация
+    const int validation_result = tag_rules_validate(tag_rules_ptr);
+    if (validation_result != 0)
+    {
+        printL(ERROR, PARSER, "Config validation failed (errors: %d)!", validation_result);
+        tag_rules_destroy(tag_rules_ptr);
         return 1;
     }
 
-    if (tag_rules_check_collisions(tag_rules_ptr->rules, size) != 0)
-    {
-        printL(ERROR, PARSER, "Error checking config file for collisions!");
-        return 1;
-    }
-
-    tag_rules_convert_to_host_order(tag_rules_ptr->rules, size);
-
-    tag_rules_ptr->size = size;
+    printL(INFO, PARSER, "Loaded %d tag rules from %s", loaded_count, config_path);
 
     return 0;
 }
@@ -126,7 +126,7 @@ int main(const int argc, char *argv[])
         }
     }
 
-    if (fill_tag_rules(&global_tag_rules)) {
+    if (fill_tag_rules(&global_tag_rules, "vlan-tagger.cfg")) {
         printL(ERROR, PARSER, "Error reading tag rules!");
 
         cleanup();

--- a/main.c
+++ b/main.c
@@ -13,6 +13,7 @@
 #include "pipeline_patterns/patterns.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#define DEFAULT_CONFIG_PATH "vlan-tagger.cfg"
 
 Pipeline global_pipeline = {};
 tag_rules_t global_tag_rules = {};
@@ -29,45 +30,24 @@ static void signal_handler(const int signal)
 static void cleanup(void)
 {
     pipeline_destroy(&global_pipeline);
-
-    tag_rules_destroy(&global_tag_rules);
-    printL(INFO, INITIATOR, "Tag rules destroyed.");
-
     stop_log();
 }
 
 static int fill_tag_rules(tag_rules_t *tag_rules_ptr, const char *config_path) {
-    // Инициализация
-    if (tag_rules_init(tag_rules_ptr, 0) != 0)
+    const int result = tag_rules_load(tag_rules_ptr, config_path);
+
+    if (result < 0)
     {
-        printL(ERROR, PARSER, "Error initializing tag rules structure!");
+        printL(ERROR, PARSER, "Error loading config (code: %d)!", result);
         return 1;
     }
 
-    // Загрузка
-    const int loaded_count = tag_rules_load_from_file(tag_rules_ptr, config_path);
-    if (loaded_count < 0)
-    {
-        printL(ERROR, PARSER, "Error loading config file (code: %d)!", loaded_count);
-        tag_rules_destroy(tag_rules_ptr);
-        return 1;
-    }
-
-    if (loaded_count == 0)
+    if (result == 0)
     {
         printL(WARNING, PARSER, "No rules loaded from config file!");
     }
 
-    // Валидация
-    const int validation_result = tag_rules_validate(tag_rules_ptr);
-    if (validation_result != 0)
-    {
-        printL(ERROR, PARSER, "Config validation failed (errors: %d)!", validation_result);
-        tag_rules_destroy(tag_rules_ptr);
-        return 1;
-    }
-
-    printL(INFO, PARSER, "Loaded %d tag rules from %s", loaded_count, config_path);
+    printL(INFO, PARSER, "Loaded %d tag rules from %s", result, config_path);
 
     return 0;
 }
@@ -126,7 +106,7 @@ int main(const int argc, char *argv[])
         }
     }
 
-    if (fill_tag_rules(&global_tag_rules, "vlan-tagger.cfg")) {
+    if (fill_tag_rules(&global_tag_rules, DEFAULT_CONFIG_PATH)) {
         printL(ERROR, PARSER, "Error reading tag rules!");
 
         cleanup();

--- a/nodes/include/tagger_node.h
+++ b/nodes/include/tagger_node.h
@@ -4,12 +4,18 @@
 #include "../../pipeline/node.h"
 #include "../../config_parser/config_parser.h"
 
+typedef struct {
+    uint32_t ip_left;   // host byte order
+    uint32_t ip_right;  // host byte order
+    int tag;
+} tagger_rule_t;
+
 typedef struct TaggerContext {
-    tag_rule_t* tag_rules;
+    tagger_rule_t* tag_rules;  // Копия правил с IP в host byte order
     int tag_rules_size;
 } TaggerContext;
 
-Node* tagger_node_create(const char* name, tag_rule_t* tag_rules, int tag_rules_size);
+Node* tagger_node_create(const char* name, const tag_rule_t* tag_rules, int tag_rules_size);
 
 void* tagger_node_process(void* node_ptr);
 

--- a/nodes/src/tagger_node.c
+++ b/nodes/src/tagger_node.c
@@ -1,12 +1,13 @@
 #include "../include/tagger_node.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <linux/if_ether.h>
 
 #include "../../logger/logger.h"
 #include "../../common.h"
-#include <stdlib.h>
-#include <string.h>
-#include <linux/if_ether.h>
 
 #ifndef VLAN_VID_MASK
 #define VLAN_VID_MASK 0x0fff   /* VLAN ID: 12 бит */
@@ -17,7 +18,7 @@
 #endif
 #define IP_HEADER_MIN_LEN 20
 
-Node *tagger_node_create(const char *name, tag_rule_t *tag_rules, const int tag_rules_size) {
+Node *tagger_node_create(const char *name, const tag_rule_t *tag_rules, const int tag_rules_size) {
     if (!name || !tag_rules || tag_rules_size <= 0) {
         return NULL;
     }
@@ -27,11 +28,24 @@ Node *tagger_node_create(const char *name, tag_rule_t *tag_rules, const int tag_
         return NULL;
     }
 
-    ctx->tag_rules = tag_rules;
+    // Создаём копию правил с IP в host byte order
+    ctx->tag_rules = calloc(tag_rules_size, sizeof(tagger_rule_t));
+    if (!ctx->tag_rules) {
+        free(ctx);
+        return NULL;
+    }
+
+    for (int i = 0; i < tag_rules_size; i++) {
+        ctx->tag_rules[i].ip_left = ntohl(tag_rules[i].ip_left.s_addr);
+        ctx->tag_rules[i].ip_right = ntohl(tag_rules[i].ip_right.s_addr);
+        ctx->tag_rules[i].tag = tag_rules[i].tag;
+    }
+
     ctx->tag_rules_size = tag_rules_size;
 
     Node *node = node_create(name, NODE_TYPE_TAGGER, tagger_node_process, ctx);
     if (!node) {
+        free(ctx->tag_rules);
         free(ctx);
         return NULL;
     }
@@ -39,11 +53,9 @@ Node *tagger_node_create(const char *name, tag_rule_t *tag_rules, const int tag_
     return node;
 }
 
-static int tagger_node_get_tag(const uint32_t addr, const tag_rule_t *tag_rules_obj, const int num_rules) {
+static int tagger_node_get_tag(const uint32_t addr, const tagger_rule_t *tag_rules_obj, const int num_rules) {
     for (int i = 0; i < num_rules; ++i) {
-        uint32_t left = ntohl(tag_rules_obj[i].ip_left.s_addr);
-        uint32_t right = ntohl(tag_rules_obj[i].ip_right.s_addr);
-        if (left <= addr && right >= addr) {
+        if (tag_rules_obj[i].ip_left <= addr && tag_rules_obj[i].ip_right >= addr) {
             return tag_rules_obj[i].tag;
         }
     }

--- a/nodes/src/tagger_node.c
+++ b/nodes/src/tagger_node.c
@@ -41,7 +41,9 @@ Node *tagger_node_create(const char *name, tag_rule_t *tag_rules, const int tag_
 
 static int tagger_node_get_tag(const uint32_t addr, const tag_rule_t *tag_rules_obj, const int num_rules) {
     for (int i = 0; i < num_rules; ++i) {
-        if (tag_rules_obj[i].ip_left.s_addr <= addr && tag_rules_obj[i].ip_right.s_addr >= addr) {
+        uint32_t left = ntohl(tag_rules_obj[i].ip_left.s_addr);
+        uint32_t right = ntohl(tag_rules_obj[i].ip_right.s_addr);
+        if (left <= addr && right >= addr) {
             return tag_rules_obj[i].tag;
         }
     }

--- a/pipeline_patterns/patterns.c
+++ b/pipeline_patterns/patterns.c
@@ -22,10 +22,12 @@ int vlan_tagger_pattern(Pipeline *pipeline, const void *ctx) {
     Node *sender = NULL;
 
     if (!((sniffer = sniffer_node_create("Sniffer", vlan_tagger_context->src_dev_name)))
-        || !((tagger1 = tagger_node_create("Tagger1", vlan_tagger_context->tag_rules->rules,
-                                           vlan_tagger_context->tag_rules->size)))
-        || !((tagger2 = tagger_node_create("Tagger2", vlan_tagger_context->tag_rules->rules,
-                                           vlan_tagger_context->tag_rules->size)))
+        || !((tagger1 = tagger_node_create("Tagger1",
+                                           tag_rules_get_array(vlan_tagger_context->tag_rules),
+                                           tag_rules_get_size(vlan_tagger_context->tag_rules))))
+        || !((tagger2 = tagger_node_create("Tagger2",
+                                           tag_rules_get_array(vlan_tagger_context->tag_rules),
+                                           tag_rules_get_size(vlan_tagger_context->tag_rules))))
         || !((counter = packet_counter_node_create("PacketCounter", 10)))
         || !((sender = sender_node_create("Sender", vlan_tagger_context->dst_dev_name)))) {
         goto __clear_and_exit;

--- a/pipeline_patterns/patterns.c
+++ b/pipeline_patterns/patterns.c
@@ -21,13 +21,11 @@ int vlan_tagger_pattern(Pipeline *pipeline, const void *ctx) {
     Node *counter = NULL;
     Node *sender = NULL;
 
+    const tag_rules_t *rules = vlan_tagger_context->tag_rules;
+
     if (!((sniffer = sniffer_node_create("Sniffer", vlan_tagger_context->src_dev_name)))
-        || !((tagger1 = tagger_node_create("Tagger1",
-                                           tag_rules_get_array(vlan_tagger_context->tag_rules),
-                                           tag_rules_get_size(vlan_tagger_context->tag_rules))))
-        || !((tagger2 = tagger_node_create("Tagger2",
-                                           tag_rules_get_array(vlan_tagger_context->tag_rules),
-                                           tag_rules_get_size(vlan_tagger_context->tag_rules))))
+        || !((tagger1 = tagger_node_create("Tagger1", rules->rules, rules->size)))
+        || !((tagger2 = tagger_node_create("Tagger2", rules->rules, rules->size)))
         || !((counter = packet_counter_node_create("PacketCounter", 10)))
         || !((sender = sender_node_create("Sender", vlan_tagger_context->dst_dev_name)))) {
         goto __clear_and_exit;


### PR DESCRIPTION
Расширена структура tag_rules_t полями size и capacity для динамического управления памятью (отказываемся от статики)

Добавлены/переписаны новый функции для config_parser:
tag_rules_init() - инициализация с динамической памятью
tag_rules_destroy() - корректное освобождение ресурсов
tag_rules_load_from_file() - загрузка с автоматическим расширением
tag_rules_validate() - комплексная валидация (3 проверки)
tag_rules_get_array() / tag_rules_get_size() - getter'ы

Переведены вызовы:
atoi() → strtol() с проверкой переполнения
strtok() → strtok_r() для thread-safety
inet_ntoa() удалена (использование прямого сравнения через ntohl())

Удалена функция ip_str_to_int() (больше не нужна)
Удалена функция tag_rules_convert_to_host_order() (костыль)

Добавлен #define _GNU_SOURCE для strtok_r (потокобезопасная версия strtok - POSIX функция, не стандарт си)